### PR TITLE
ungoogled-chromium-macchrome: Fix error related to new version from upstream (Closes #1)

### DIFF
--- a/ungoogled-chromium-macchrome.json
+++ b/ungoogled-chromium-macchrome.json
@@ -29,7 +29,7 @@
     "persist": "User Data",
     "checkver": {
         "github": "https://github.com/macchrome/winchrome",
-        "regex": "Chromium v([\\d.]+)-r(?<rev>\\d+) - ungoogled"
+        "regex": "Chromium v([\\d.]+)-6-r(?<rev>\\d+) - ungoogled"
     },
     "autoupdate": {
         "architecture": {

--- a/ungoogled-chromium-macchrome.json
+++ b/ungoogled-chromium-macchrome.json
@@ -8,7 +8,7 @@
         "64bit": {
             "url": "https://github.com/macchrome/winchrome/releases/download/v102.0.5005.63-6-r992738-Win64/ungoogled-chromium-102.0.5005.63-6_Win64.7z",
             "hash": "sha1:D907E5A5F5B4B784F8326E3DCAC55461792806A7",
-            "extract_dir": "ungoogled-chromium-102.0.5005.63-6-1_Win64"
+            "extract_dir": "ungoogled-chromium-102.0.5005.63-6_Win64"
         }
     },
     "bin": [

--- a/ungoogled-chromium-macchrome.json
+++ b/ungoogled-chromium-macchrome.json
@@ -34,8 +34,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-r$matchRev-Win64/ungoogled-chromium-$version-1_Win64.7z",
-                "extract_dir": "ungoogled-chromium-$version-1_Win64"
+                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-r$matchRev-Win64/ungoogled-chromium-$version_Win64.7z",
+                "extract_dir": "ungoogled-chromium-$version_Win64"
             }
         },
         "hash": {


### PR DESCRIPTION
"-6" in version name cause problems with extraction process, checkver and autoupdate